### PR TITLE
Mudei o hover do título e coloquei o loading

### DIFF
--- a/css/master.css
+++ b/css/master.css
@@ -46,7 +46,15 @@ img {
     display: none;
 }
 
-
+.load {
+    position: fixed;
+    left: 0px;
+    top: 0px;
+    width: 100%;
+    height: 100%;
+    z-index: 9999;
+    background: url('../images/loading.gif') 50% 50% no-repeat white;
+}
 
 /* Header */
 header {
@@ -263,8 +271,8 @@ main .main-content .filme img:hover {
 }
 
 main .main-content .filme .title {
+    display: inline-block;
     color: #fff;
-    max-width: 200px;
     padding: 10px 0;
     transition: all 0.5s;
 }

--- a/index.html
+++ b/index.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt-br">
 
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Document</title>
+    <title>Projeto LS</title>
     <link rel="stylesheet" href="css/master.css">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css">
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
 </head>
 
-<body>
+<body onload="loading();">
+    <div id="load" class="load"></div>
     <header>
         <div class="header container">
             <div class="logo-btn_menu">
@@ -63,6 +64,9 @@
                 $('nav').toggleClass('active')
             })
         })
+        function loading(){
+            $('#load').css('display','none');
+        }
     </script>
     <script src="dist/main.js"></script>
 </body>

--- a/pages/movie.html
+++ b/pages/movie.html
@@ -11,6 +11,7 @@
     <title>Document</title>
 </head>
 <body>
+
     <header>
         <div class="header container">
             <div class="logo-btn_menu">
@@ -27,7 +28,7 @@
         </div>
     </header>
 
-    <main class="container">
+    <main class="container" id="tudo_page" style="display: none;">
         <div class="movie-content"></div>
     </main>
 
@@ -50,6 +51,7 @@
                 $('nav').toggleClass('active')
             })
         })
+        
     </script>
     <script src="../dist/movie.js"></script>
     <script src="../js/lightbox.js"></script>


### PR DESCRIPTION
Eu mudei o hover do título como você pediu. Por padrão os Headings vem com display block, isso faz ele ocupar toda a linha(width: 100%), então por isso que no hover ele estava pegando ao lado dele também. Para pegar somente o tamanho de seu conteúdo, é só colocar display inline-block.
Também coloquei um loading simples na página inicial, se precisar colocar em outras páginas, tenho certeza que você conseguirá colocar só olhando o código como fiz.